### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dfinity/execution
+* @dfinity/team-dsm

--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Post to a Slack channel
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         with:
-          channel-id: eng-execution-mrs
+          channel-id: eng-dsm-prs
           slack-message: ":github: `${{ github.repository }}` <${{ github.event.pull_request.html_url }}|${{ steps.sanitize.outputs.safe_title }}>"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}


### PR DESCRIPTION
This PR replaces `@dfinity/execution` with `@dfinity/team-dsm` in CODEOWNERS.
