### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Lint
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build

--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Sanitize PR title
         id: sanitize

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
           echo "can_add_commit=${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY != '' && github.event_name == 'pull_request' }}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
@@ -28,14 +28,14 @@ jobs:
 
       - name: Checkout with token
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.app-token.outputs.token }}
       - name: Checkout without token
         if: steps.check_can_add_commit.outputs.can_add_commit == 'false'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -47,7 +47,7 @@ jobs:
         run: npm run docs
 
       - name: Commit docs
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         # We don't want to commit documentation changes to main
         if: ${{ github.ref != 'refs/heads/main' }}
         with:
@@ -65,7 +65,7 @@ jobs:
           fi
       - name: Commit docs changes
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true' && steps.check_docs.outputs.docs_needed == 'true'
-        uses: EndBug/add-and-commit@v9.1.4
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
           add: .
           default_author: github_actions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Prepare
         uses: ./.github/actions/prepare
       - run: npm run build
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build next version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Lint


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions/create-github-app-token@v1` -> `actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0`
  - Version: v1.12.0 | Latest: v3.0.0 | Release age: 27d
  - Commit: https://github.com/actions/create-github-app-token/commit/d72941d797fd3113feb6b93fd0dec494b13a2547

- `EndBug/add-and-commit@v9` -> `EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4`
  - Version: v9.1.4 | Latest: v10.0.0 | Release age: 18d
  - Commit: https://github.com/EndBug/add-and-commit/commit/a94899bca583c204427a224a7af87c02f9b325d5

- `EndBug/add-and-commit@v9.1.4` -> `EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4`
  - Version: v9.1.4 | Latest: v10.0.0 | Release age: 18d
  - Commit: https://github.com/EndBug/add-and-commit/commit/a94899bca583c204427a224a7af87c02f9b325d5

- `actions/checkout@v5` -> `actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1`
  - Version: v5.0.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/93cb6efe18208431cddfb8368fd83d5badbf9bfd


### Files modified

- `.github/workflows/checks.yml`
- `.github/workflows/ci-notify-slack.yml`
- `.github/workflows/docs.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/tests.yml`